### PR TITLE
Fix DataFusion console from script source

### DIFF
--- a/src/bin/console/main.rs
+++ b/src/bin/console/main.rs
@@ -49,9 +49,10 @@ fn setup_console(cmdline: clap::ArgMatches) {
                         Ok(cmd) => {
                             cmd_buffer.push_str(&cmd);
                             if cmd_buffer.as_str().ends_with(";") {
-                                console.execute(&cmd_buffer[0..cmd_buffer.len() - 2]);
+                                console.execute(&cmd_buffer[0..cmd_buffer.len() - 1]);
                                 cmd_buffer = String::new();
                             }
+                            cmd_buffer.push_str("\n");
                         }
                         Err(e) => println!("Error: {}", e),
                     }


### PR DESCRIPTION
SQL scripts which contains line breaks were not properly parsed. While
iterating over lines, the current line does not contain the line break
character and the generated SQL wasn't well formed (as it missed that
line break charaters).

For example, if the input script contained:

```
SELECT * FROM new_uk_cities
LIMIT 5;
```

The console was receiving:

```
SELECT * FROM new_uk_citiesLIMIT 5;
```